### PR TITLE
Minimum Required iOS version to 8.0

### DIFF
--- a/CSSParser.podspec
+++ b/CSSParser.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/mcudich/CSSParser.git", :tag => s.version.to_s, :submodules => true }
   s.social_media_url = "https://twitter.com/mcudich"
 
-  s.ios.deployment_target = "9.3"
+  s.ios.deployment_target = "8.0"
 
   s.source_files = "Sources/**/*", "Carthage/Checkouts/katana-parser/src/*"
   s.public_header_files = "Sources/CSSParser.h"


### PR DESCRIPTION
I've made local Pod from my fork where I just down minimum required version to 8.0 and it works locally.
I cannot get the Pod simlpy from my fork as it requires submodule